### PR TITLE
fix minor (whitespace) gofmt delta

### DIFF
--- a/internal/golang.org/x/net/context/context.go
+++ b/internal/golang.org/x/net/context/context.go
@@ -34,7 +34,7 @@
 //
 // See http://blog.golang.org/context for example code for a server that uses
 // Contexts.
-package context 
+package context
 
 import (
 	"errors"


### PR DESCRIPTION
One file shows as not gofmt-compatible (some trailing space):

$ find . -name '*.go' | xargs gofmt -l
./internal/golang.org/x/net/context/context.go

May be worth to add a pre-commit check with gofmt in the repository.
