### PR TITLE
verifier authentication (fixes #17)

### DIFF
--- a/keyserver/server_test.go
+++ b/keyserver/server_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
+	"fmt"
 	"io/ioutil"
 	"log"
 	mathrand "math/rand"
@@ -705,7 +706,7 @@ func setupVerifier(t *testing.T, keyserverVerif *proto.AuthorizationPolicy, keys
 	}
 	sv = &proto.PublicKey{Ed25519: pk[:]}
 
-	cert := tlstestutil.Cert(t, caCert, caKey, "127.0.0.1", nil)
+	cert := tlstestutil.Cert(t, caCert, caKey, fmt.Sprintf("verifier %x", proto.KeyID(sv)), nil)
 	getKey = func(keyid string) (crypto.PrivateKey, error) {
 		switch keyid {
 		case "signing":


### PR DESCRIPTION
As detailed earlier on the Trello board:

> To reiterate, the plan here is to sign TLS client certificates for verifiers which contain a per-verifier unique uint64 ID in the common name. Probably, the process for signing the client certs will be manual. (We don't actually need to vet the verifiers much here; it's the clients (or the extension writers...) that need to decide whom to trust how much, and adding bad verifiers doesn't hurt security.) Then, verifiers can present their client certs and upload arbitrary signatures for each epoch associated with the ID in the cert, which will get stored in the tableRatifications LevelDB "table" and served back to clients who request them. We thought about checking the signatures themselves rather than authenticating verifiers by client cert, but this would limit verifiers to signature schemes that we support, which we'd rather avoid.