### PR TITLE
add Travis and godoc banners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ before_install:
         # for git to use when cloning from googlesource.com to
         # bypass "bandwidth rate limit exceeded" error.
         # See https://github.com/golang/go/issues/12933 for details
-        - openssl aes-256-cbc -K $encrypted_3a7b75acb9d9_key -iv $encrypted_3a7b75acb9d9_iv -in .gitcookies.enc -out .gitcookies.sh -d
-        - bash .gitcookies.sh
+        # Skip for Pull Requests to avoid Travis failure.
+        - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_139df71bd95f_key -iv $encrypted_139df71bd95f_iv -in .gitcookies.enc -out .gitcookies -d && bash .gitcookies.sh || true'
 go: 
  - 1.5
  - 1.6

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+### coname [![Build Status](https://travis-ci.org/yahoo/coname.svg?branch=master)](https://travis-ci.org/yahoo/coname) [![GoDoc](https://godoc.org/github.com/yahoo/coname?status.svg)](http://godoc.org/github.com/yahoo/coname)
+
+
 This repository contains a WORK-IN-PROGRESS implementation of an EXPERIMENTAL
 cooperative keyserver design based on ideas from `dename`
 ([readme, code](https://github.com/andres-erbsen/dename),


### PR DESCRIPTION
banners can be previewed on https://github.com/dmitris/coname/tree/travis-banner .  Adding them will make eventual Travis build failures more visible 😄 

@maditya 